### PR TITLE
Run service features in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ To run a specific test add the file path after the command
 bundle exec features/path/to/feature.feature
 ```
 
+To run the tests for each service in parallel, run the command
+
+```shell
+bin/parallel_cucumber.rb <profile> <test_env>
+```
+
+Separate terminals will open up for each service where the tests will then be run.
+Note, this only works on a Mac.
+
 ### Profiles and Tags
 
 As will as the default cucumber profiles (`default`, `rerun`, `wip`) we have an additional `accessibility` profile.

--- a/bin/parallel_cucumber.rb
+++ b/bin/parallel_cucumber.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+profile   = ARGV[0] || 'smoulder'
+test_env  = ARGV[1] || 'local'
+
+# services = %w[facilities_management legal_services management_consultancy supply_teachers]
+services = %w[legal_services management_consultancy supply_teachers]
+
+windows = services.map do |service|
+  open_terminal_cmd = `osascript -e 'tell app "Terminal" to do script "cd ~/Code/dfp-repos/crown-marketplace-feature-tests && echo Running tests for: #{service} && CUCUMBER_FORMAT=progress TEST_ENV=#{test_env} bundle exec cucumber -p #{profile} features/services/#{service}/"'`
+
+  open_terminal_cmd[19..]
+end
+
+services.zip(windows).each do |service, window_id|
+  print("Close window for #{service} (ID: #{window_id}): ")
+  close_window = $stdin.gets.chomp.downcase
+
+  `osascript -e 'tell application "Terminal" to close window id #{window_id}'` if ['yes', 'y'].include?(close_window)
+end

--- a/features/helpers/download_helpers.rb
+++ b/features/helpers/download_helpers.rb
@@ -3,14 +3,30 @@ module DownloadHelpers
   TIMEOUT = 10
 
   class << self
-    def downloads
-      Dir["#{PATH}/*"].sort_by { |file| File.mtime(file) }
+    def download_path
+      test_run_id = ENV.fetch('TEST_RUN_ID', nil)
+
+      if test_run_id
+        File.join(PATH, test_run_id)
+      else
+        PATH
+      end.to_s
+    end
+
+    def clear_downloads
+      FileUtils.rm_rf(download_path)
     end
 
     def download_file_name
       wait_for_download
 
       File.basename(downloads.last)
+    end
+
+    private
+
+    def downloads
+      Dir["#{download_path}/*"].sort_by { |file| File.mtime(file) }
     end
 
     def wait_for_download
@@ -25,10 +41,6 @@ module DownloadHelpers
 
     def downloading?
       downloads.grep(/\.part$/).any?
-    end
-
-    def clear_downloads
-      FileUtils.rm_f(downloads)
     end
   end
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -43,6 +43,8 @@ ENV['BUYER_PASSWORD'] ||= config['users']['buyer']['password']
 ENV['ADMIN_EMAIL']    ||= config['users']['admin']['email']
 ENV['ADMIN_PASSWORD'] ||= config['users']['admin']['password']
 
+ENV['TEST_RUN_ID'] = SecureRandom.uuid
+
 # Set the Capybara config
 Capybara.app_host = config['host']
 
@@ -52,7 +54,7 @@ Capybara.register_driver :selenium do |app|
   options.add_argument('-headless') if ENV.fetch('HEADLESS', 'true') == 'true'
 
   options.add_preference('browser.download.folderList', 2)
-  options.add_preference('browser.download.dir', DownloadHelpers::PATH.to_s)
+  options.add_preference('browser.download.dir', DownloadHelpers.download_path)
 
   Capybara::Selenium::Driver.new(app, browser: :firefox, options:)
 end


### PR DESCRIPTION
Create a script which will allow us to run the features for each service in parallel.

Update the download options to account for these changes so that all files are downloaded to a folder unique for the test run.